### PR TITLE
added mentions to underscore rejections

### DIFF
--- a/_projects/de/2021-09-02-TTN-Umzug.md
+++ b/_projects/de/2021-09-02-TTN-Umzug.md
@@ -57,7 +57,7 @@ Lasse den Tab geöffnet. Im nächsten Schritt wird eine neue Application in der 
 
 {% include image.html image="/images/projects/TTN_Umzug/ttnv3-console.png" %}
 
-Und erstelle mit dem "+ Add Application" eine neue Application. Gebe hier die Application ID an. **Kopiere diese aus der TTNv2 Konsole und achte darauf, dass die Application ID dieselbe ist.** Erstelle daraufhin die Application mit dem "Create application" Button.
+Und erstelle mit dem "+ Add Application" eine neue Application. Gebe hier die Application ID an. **Kopiere diese aus der TTNv2 Konsole und achte darauf, dass die Application ID dieselbe ist. Falls du Unterstriche genutzt hast, musst du diese in V3 durch Bindestriche ersetzen.** Erstelle daraufhin die Application mit dem "Create application" Button.
 
 {% include image.html image="/images/projects/TTN_Umzug/ttnv3-create-application.png" %}
 
@@ -75,7 +75,7 @@ Im unteren Teil werden nun die EUIs aus der TTNv2 Konsole übernommen. Wechsle e
 
 {% include image.html image="/images/projects/TTN_Umzug/ttnv3-paste-euis.png" %}
 
-Zuletzt muss noch die "End device ID" übertragen werden. Kopiere also die "Device ID" aus TTNv2 und kopiere diese in TTNv3.
+Zuletzt muss noch die "End device ID" übertragen werden. Kopiere also die "Device ID" aus TTNv2 und kopiere diese in TTNv3. **Falls du Unterstriche genutzt hast, musst du diese auch hier in V3 durch Bindestriche ersetzen.**
 
 Registriere nun das neue Device mit dem "Register end device" Button.
 
@@ -129,4 +129,4 @@ Zuletzt muss die senseBox neu gestartet werden (kurz vom Strom nehmen). Nun soll
 
 ### openSenseMap
 
-Auf der openSenseMap müssen keine Anpassungen vorgenommen werden solange die "Application ID" und "Device ID" gleich bleiben.
+Auf der openSenseMap müssen keine Anpassungen vorgenommen werden solange die "Application ID" und "Device ID" gleich bleiben. **Wenn du aufgrund von Unterstrichen die IDs ändern musstest, musst du dies in der OpenSenseMap natürlich anpassen.**


### PR DESCRIPTION
Added mentions of underscore rejection by TTNv3 and resulting additional steps, as mentioned here:
```
Es gab noch eine kleinere Herausforderung. Ihr schreibt ja, dass man in der neuen Umgebung exakt die gleiche ID wie bisher für die Application verwenden sollte. Das war in meinem Fall nicht möglich. Ich hatte leider die IDs für Application und Device mit Unterstrichen als Trenner angegeben. Diese werden von der neuen TTN-Oberfläche aber nicht mehr akzeptiert. Ich habe daher nun Bindestriche angegeben.

An der Sensebox selbst war hierdurch zum Glück nichts zu ändern. Der Arduino Code verwendet ausschließlich die hexadezimalen IDs.

Die entscheidende Änderung war dann in der Sensebox Administration, also in "Eurer" Oberfläche zu machen. Und zwar im Menüpunkt TTN. Dort musste ich dann noch die Variante der IDs mit den Bindestrichen eintragen.

Nun kommen wieder Daten in der OpenSenseMap an.
```